### PR TITLE
Generalise MessagePack.fromObject to Monad m.

### DIFF
--- a/src/msgpack/Data/MessagePack/Generic.hs
+++ b/src/msgpack/Data/MessagePack/Generic.hs
@@ -10,7 +10,7 @@
 {-# LANGUAGE TypeOperators       #-}
 module Data.MessagePack.Generic () where
 
-import           Control.Applicative     ((<$>), (<*>), (<|>))
+import           Control.Applicative     (Applicative, (<$>), (<*>), (<|>))
 import           Control.Monad           ((>=>))
 import           Data.Bits               (shiftR)
 import           Data.Word               (Word64)
@@ -22,8 +22,8 @@ import           Data.MessagePack.Object (Object (..))
 
 instance GMessagePack U1 where
   gToObject U1 = ObjectNil
-  gFromObject ObjectNil = Just U1
-  gFromObject _ = Nothing
+  gFromObject ObjectNil = return U1
+  gFromObject _ = fail "invalid encoding for custom unit type"
 
 instance (GMessagePack a, GProdPack b) => GMessagePack (a :*: b) where
   gToObject = toObject . prodToObject
@@ -53,7 +53,7 @@ instance MessagePack a => GMessagePack (K1 i a) where
 
 class GProdPack f where
   prodToObject :: f a -> [Object]
-  prodFromObject :: [Object] -> Maybe (f a)
+  prodFromObject :: (Functor m, Applicative m, Monad m) => [Object] -> m (f a)
 
 
 instance (GMessagePack a, GProdPack b) => GProdPack (a :*: b) where
@@ -69,13 +69,13 @@ instance GMessagePack a => GProdPack (M1 t c a) where
 
 -- Sum type packing.
 
-checkSumFromObject0 :: (GSumPack f) => Word64 -> Word64 -> Maybe (f a)
+checkSumFromObject0 :: (Functor m, Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> m (f a)
 checkSumFromObject0 size code
   | code < size = sumFromObject code size ObjectNil
   | otherwise   = fail "unknown encoding for constructor"
 
 
-checkSumFromObject :: (GSumPack f) => Word64 -> Word64 -> Object -> Maybe (f a)
+checkSumFromObject :: (Functor m, Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> Object -> m (f a)
 checkSumFromObject size code x
   | code < size = sumFromObject code size x
   | otherwise   = fail "unknown encoding for constructor"
@@ -83,7 +83,7 @@ checkSumFromObject size code x
 
 class GSumPack f where
   sumToObject :: Word64 -> Word64 -> f a -> Object
-  sumFromObject :: Word64 -> Word64 -> Object -> Maybe (f a)
+  sumFromObject :: (Functor m, Applicative m, Monad m) => Word64 -> Word64 -> Object -> m (f a)
 
 
 instance (GSumPack a, GSumPack b) => GSumPack (a :+: b) where

--- a/src/tox/Network/Tox/Crypto/Key.lhs
+++ b/src/tox/Network/Tox/Crypto/Key.lhs
@@ -116,8 +116,8 @@ keyToInteger =
 decode :: (CryptoNumber a, Monad m) => ByteString.ByteString -> m (Key a)
 decode bytes =
   case Sodium.decode bytes of
-    Nothing  -> fail $ "Unable to decode ByteString: " ++ show bytes
     Just key -> return $ Key key
+    Nothing  -> fail $ "unable to decode ByteString to Key: " ++ show bytes
 
 
 instance CryptoNumber a => Binary (Key a) where
@@ -137,7 +137,7 @@ instance CryptoNumber a => Read (Key a) where
 
 instance CryptoNumber a => MessagePack (Key a) where
   toObject = toObject . Sodium.encode
-  fromObject = fromObject >=> Sodium.decode
+  fromObject = fromObject >=> decode
 
 
 {-------------------------------------------------------------------------------

--- a/src/tox/Network/Tox/DHT/RpcPacket.lhs
+++ b/src/tox/Network/Tox/DHT/RpcPacket.lhs
@@ -32,7 +32,9 @@ responding to.
 \begin{code}
 
 newtype RequestId = RequestId Word64
-  deriving (Eq, Read, Show, Binary, Arbitrary, MessagePack)
+  deriving (Eq, Read, Show, Binary, Arbitrary, Generic)
+
+instance MessagePack RequestId
 
 \end{code}
 

--- a/src/tox/Network/Tox/NodeInfo/PortNumber.lhs
+++ b/src/tox/Network/Tox/NodeInfo/PortNumber.lhs
@@ -28,7 +28,9 @@ import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 
 
 newtype PortNumber = PortNumber Word16
-  deriving (Eq, Show, Read, Generic, Typeable, Binary, Num, MessagePack)
+  deriving (Eq, Show, Read, Generic, Typeable, Binary, Num)
+
+instance MessagePack PortNumber
 
 
 {-------------------------------------------------------------------------------


### PR DESCRIPTION
fromObject used to return Maybe a, now it returns m a. We use "fail" from Monad
to return Nothing for Maybe. In the future, MonadFail[1] will replace Monad, but
not anytime soon, since we need to be compatible with base <= 4.8, and MonadFail
is since 4.9.0.0.

[1] https://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Monad-Fail.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/9)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231053531%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231145901%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231308504%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231311113%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231330619%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231331037%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231335460%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/TokTok/hstox/pull/9%23issuecomment-231053531%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6904791/badge%29%5D%28https%3A//coveralls.io/builds/6904791%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A0c499866585fc8a89c65ad9936b3b21c8780ae79%20on%20iphydf%3Amonad-decode%2A%2A%20into%20%2A%2Adf99d89ffcdaf50fb03f9254009ef68532c9d9b6%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-07T11%3A34%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6909907/badge%29%5D%28https%3A//coveralls.io/builds/6909907%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2Ad76c36c8f1619794e73e82dd1626b727102cc948%20on%20iphydf%3Amonad-decode%2A%2A%20into%20%2A%2Ab09801f30f173e74ba2c2b88dfb91e508e8f8f96%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-07T17%3A16%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReview%20status%3A%200%20of%205%20files%20reviewed%20at%20latest%20revision%2C%206%20unresolved%20discussions.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%2082%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM6EnzNnLcJtg1ottlS%3A-KM6EnzNnLcJtg1ottlT%3A-2090853668%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L82%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%5Cn%3E%20%5Cn%3E%20--%20integral%20instances%5Cn%3E%20%60%60%60%5Cn%5Cnnit%3A%20capital%20and%20period%20at%20end.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%2094%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8gQkPNU9_QY8aI993%3A-KM8gQkPNU9_QY8aI994%3A-478147546%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L94%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%20%20fromObject%20%3D%20%5C%5Ccase%5Cn%3E%20%20%20%20%20ObjectInt%20n%20-%3E%20return%20n%5Cn%3E%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20-%3E%20fail%20%5C%22invalid%20integer%20encoding%5C%22%5Cn%3E%20%60%60%60%5Cn%5CnShould%20we%20have%20a%20standard%20wording%20for%20the%20error%20messages%3F%20ie%3A%20%5C%22invalid%20X%20encoding%5C%22%20or%20%5C%22invalid%20encoding%20for%20X%5C%22%20%3F%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20107%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM6Fg-Nhasgs7HRTUgv%3A-KM6BuxCrfSLsFLs4BkY%3A-1724527325%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L107%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%5Cn%3E%20%5Cn%3E%20--%20core%20instances%5Cn%3E%20%60%60%60%5Cn%5Cnnitpick%3A%20capitalize%20and%20period%20at%20end.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20168%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8g4kQoW-NzMJaVFeD%3A-KM8g4kRFwjsMVOgfe3t%3A297925641%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L168%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%5Cn%3E%20%5Cn%3E%20--%20util%20instances%5Cn%3E%20%60%60%60%5Cn%5Cnnitpick%3A%20capital%20%2B%20period%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20170%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8g7NzsX64CMtppHrr%3A-KM8g7NzsX64CMtppHrs%3A-1211009611%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L170%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20--%20util%20instances%5Cn%3E%20%5Cn%3E%20--%20nullable%5Cn%3E%20%60%60%60%5Cn%5Cnnitpick%3A%20make%20into%20sentence%20maybe%3F%20%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20192%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8gdayv0inKNL7vv73%3A-KM8gdayv0inKNL7vv74%3A-747174374%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L192%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%20%20fromObject%20%3D%20%5C%5Ccase%5Cn%3E%20%20%20%20%20ObjectStr%20s%20-%3E%20return%20s%5Cn%3E%20%20%20%20%20_%20%20%20%20%20%20%20%20%20%20%20-%3E%20fail%20%5C%22invalid%20text%5C%22%5Cn%3E%20%60%60%60%5Cn%5CnAgain%2C%20maybe%20have%20a%20standard%20wording%20for%20the%20error%20messages%3F%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T08%3A51%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/666148%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/neduard%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReview%20status%3A%200%20of%205%20files%20reviewed%20at%20latest%20revision%2C%206%20unresolved%20discussions.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%2094%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8gQkPNU9_QY8aI993%3A-KM8jZ6JKC0V41X8iAbq%3A-913260605%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L94%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20Should%20we%20have%20a%20standard%20wording%20for%20the%20error%20messages%3F%20ie%3A%20%5C%22invalid%20X%20encoding%5C%22%20or%20%5C%22invalid%20encoding%20for%20X%5C%22%20%3F%5Cn%3C/details%3E%5CnYes%2C%20I%20agree.%20Which%20format%20would%20you%20prefer%3F%20Invalid%20encoding%20for%20X%20is%20easier%20to%20grep%20for%20in%20logs.%20Invalid%20X%20encoding%20is%20shorter.%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T09%3A04%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10647936%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iphydf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReview%20status%3A%200%20of%205%20files%20reviewed%20at%20latest%20revision%2C%206%20unresolved%20discussions.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%2082%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM6EnzNnLcJtg1ottlS%3A-KM95yvqN0Lc-JDmGjsl%3A-499146009%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L82%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20nit%3A%20capital%20and%20period%20at%20end.%5Cn%3C/details%3E%5CnDone.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%2094%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8gQkPNU9_QY8aI993%3A-KM95zexGIe6SIT4V4M3%3A-499146009%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L94%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20iphydf%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20Yes%2C%20I%20agree.%20Which%20format%20would%20you%20prefer%3F%20Invalid%20encoding%20for%20X%20is%20easier%20to%20grep%20for%20in%20logs.%20Invalid%20X%20encoding%20is%20shorter.%5Cn%3C/details%3E%5CnDone.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20107%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM6Fg-Nhasgs7HRTUgv%3A-KM96-PVJGV6rOYr5SmY%3A-499146009%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L107%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20nitpick%3A%20capitalize%20and%20period%20at%20end.%5Cn%3C/details%3E%5CnDone.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20168%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8g4kQoW-NzMJaVFeD%3A-KM9616csMBNXi6iAjec%3A-496375446%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L168%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20nitpick%3A%20capital%20%2B%20period%5Cn%3C/details%3E%5CnGone.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20170%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8g7NzsX64CMtppHrr%3A-KM9626_EUCAg6b7_B8t%3A-499146009%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L170%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20nitpick%3A%20make%20into%20sentence%20maybe%3F%20%5Cn%3C/details%3E%5CnDone.%5Cn%5Cn---%5Cn%5Cn%2A%5Bsrc/msgpack/Data/MessagePack/Class.hs%2C%20line%20192%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%23-KM8gdayv0inKNL7vv73%3A-KM963nwiPyftvRq6YDq%3A-499146009%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs%23L192%29%29%3A%2A%5Cn%3Cdetails%3E%3Csummary%3E%3Ci%3EPreviously%2C%20neduard%20%28Eduard%20Nicodei%29%20wrote%5Cu2026%3C/i%3E%3C/summary%3E%5Cn%3E%20Again%2C%20maybe%20have%20a%20standard%20wording%20for%20the%20error%20messages%3F%5Cn%3C/details%3E%5CnDone.%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/9%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T10%3A45%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10647936%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iphydf%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6921570/badge%29%5D%28https%3A//coveralls.io/builds/6921570%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A5cd0fd02be356f8d2033b034333367394ccec49c%20on%20iphydf%3Amonad-decode%2A%2A%20into%20%2A%2Acab577db52dc38191236ed53de6ac1a5e4d5558d%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T10%3A48%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6921844/badge%29%5D%28https%3A//coveralls.io/builds/6921844%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A0c52a61f23307522d1b01cb34d7ec445f1593c46%20on%20iphydf%3Amonad-decode%2A%2A%20into%20%2A%2Acab577db52dc38191236ed53de6ac1a5e4d5558d%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A15%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/TokTok/hstox/pull/9#issuecomment-231053531'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6904791/badge)](https://coveralls.io/builds/6904791)
Coverage remained the same at 91.111% when pulling **0c499866585fc8a89c65ad9936b3b21c8780ae79 on iphydf:monad-decode** into **df99d89ffcdaf50fb03f9254009ef68532c9d9b6 on TokTok:master**.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6909907/badge)](https://coveralls.io/builds/6909907)
Coverage remained the same at 91.111% when pulling **d76c36c8f1619794e73e82dd1626b727102cc948 on iphydf:monad-decode** into **b09801f30f173e74ba2c2b88dfb91e508e8f8f96 on TokTok:master**.
- <a href='https://github.com/neduard'><img border=0 src='https://avatars.githubusercontent.com/u/666148?v=3' height=16 width=16'></a> Review status: 0 of 5 files reviewed at latest revision, 6 unresolved discussions.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 82 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM6EnzNnLcJtg1ottlS:-KM6EnzNnLcJtg1ottlT:-2090853668) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L82)):*
> ```Haskell
>
>
> -- integral instances
> ```
nit: capital and period at end.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 94 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8gQkPNU9_QY8aI993:-KM8gQkPNU9_QY8aI994:-478147546) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L94)):*
> ```Haskell
>   fromObject = \case
>     ObjectInt n -> return n
>     _           -> fail "invalid integer encoding"
> ```
Should we have a standard wording for the error messages? ie: "invalid X encoding" or "invalid encoding for X" ?
---
*[src/msgpack/Data/MessagePack/Class.hs, line 107 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM6Fg-Nhasgs7HRTUgv:-KM6BuxCrfSLsFLs4BkY:-1724527325) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L107)):*
> ```Haskell
>
>
> -- core instances
> ```
nitpick: capitalize and period at end.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 168 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8g4kQoW-NzMJaVFeD:-KM8g4kRFwjsMVOgfe3t:297925641) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L168)):*
> ```Haskell
>
>
> -- util instances
> ```
nitpick: capital + period
---
*[src/msgpack/Data/MessagePack/Class.hs, line 170 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8g7NzsX64CMtppHrr:-KM8g7NzsX64CMtppHrs:-1211009611) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L170)):*
> ```Haskell
> -- util instances
>
> -- nullable
> ```
nitpick: make into sentence maybe?
---
*[src/msgpack/Data/MessagePack/Class.hs, line 192 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8gdayv0inKNL7vv73:-KM8gdayv0inKNL7vv74:-747174374) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L192)):*
> ```Haskell
>   fromObject = \case
>     ObjectStr s -> return s
>     _           -> fail "invalid text"
> ```
Again, maybe have a standard wording for the error messages?
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/toktok/hstox/9)*
<!-- Sent from Reviewable.io -->
- <a href='https://github.com/iphydf'><img border=0 src='https://avatars.githubusercontent.com/u/10647936?v=3' height=16 width=16'></a> Review status: 0 of 5 files reviewed at latest revision, 6 unresolved discussions.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 94 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8gQkPNU9_QY8aI993:-KM8jZ6JKC0V41X8iAbq:-913260605) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L94)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> Should we have a standard wording for the error messages? ie: "invalid X encoding" or "invalid encoding for X" ?
</details>
Yes, I agree. Which format would you prefer? Invalid encoding for X is easier to grep for in logs. Invalid X encoding is shorter.
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/toktok/hstox/9)*
<!-- Sent from Reviewable.io -->
- <a href='https://github.com/iphydf'><img border=0 src='https://avatars.githubusercontent.com/u/10647936?v=3' height=16 width=16'></a> Review status: 0 of 5 files reviewed at latest revision, 6 unresolved discussions.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 82 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM6EnzNnLcJtg1ottlS:-KM95yvqN0Lc-JDmGjsl:-499146009) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L82)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> nit: capital and period at end.
</details>
Done.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 94 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8gQkPNU9_QY8aI993:-KM95zexGIe6SIT4V4M3:-499146009) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L94)):*
<details><summary><i>Previously, iphydf wrote…</i></summary>
> Yes, I agree. Which format would you prefer? Invalid encoding for X is easier to grep for in logs. Invalid X encoding is shorter.
</details>
Done.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 107 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM6Fg-Nhasgs7HRTUgv:-KM96-PVJGV6rOYr5SmY:-499146009) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L107)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> nitpick: capitalize and period at end.
</details>
Done.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 168 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8g4kQoW-NzMJaVFeD:-KM9616csMBNXi6iAjec:-496375446) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L168)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> nitpick: capital + period
</details>
Gone.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 170 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8g7NzsX64CMtppHrr:-KM9626_EUCAg6b7_B8t:-499146009) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L170)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> nitpick: make into sentence maybe?
</details>
Done.
---
*[src/msgpack/Data/MessagePack/Class.hs, line 192 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/9#-KM8gdayv0inKNL7vv73:-KM963nwiPyftvRq6YDq:-499146009) ([raw file](https://github.com/toktok/hstox/blob/d76c36c8f1619794e73e82dd1626b727102cc948/src/msgpack/Data/MessagePack/Class.hs#L192)):*
<details><summary><i>Previously, neduard (Eduard Nicodei) wrote…</i></summary>
> Again, maybe have a standard wording for the error messages?
</details>
Done.
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/toktok/hstox/9)*
<!-- Sent from Reviewable.io -->
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6921570/badge)](https://coveralls.io/builds/6921570)
Coverage remained the same at 91.111% when pulling **5cd0fd02be356f8d2033b034333367394ccec49c on iphydf:monad-decode** into **cab577db52dc38191236ed53de6ac1a5e4d5558d on TokTok:master**.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6921844/badge)](https://coveralls.io/builds/6921844)
Coverage remained the same at 91.111% when pulling **0c52a61f23307522d1b01cb34d7ec445f1593c46 on iphydf:monad-decode** into **cab577db52dc38191236ed53de6ac1a5e4d5558d on TokTok:master**.


<a href='https://www.codereviewhub.com/TokTok/hstox/pull/9?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/TokTok/hstox/pull/9?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/TokTok/hstox/pull/9'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>