### PR TITLE
Enable AddressSanitizer[1] on test-hstox C code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ configure: .configure.stamp
 .configure.stamp: .libsodium.stamp
 	cabal update
 	cabal install --enable-tests $(EXTRA_DIRS) --only-dependencies hstox.cabal
-	cabal configure --enable-tests $(EXTRA_DIRS) $(ENABLE_COVERAGE) --disable-profiling
+	cabal configure -f asan --enable-tests $(EXTRA_DIRS) $(ENABLE_COVERAGE) --disable-profiling
 	@touch $@
 
 doc: $(DOCS)

--- a/hstox.cabal
+++ b/hstox.cabal
@@ -16,6 +16,10 @@ source-repository head
   type: git
   location: https://github.com/iphydf/hstox
 
+flag asan
+  description: Build C code with -fsanitize=address
+  default: False
+
 flag library-only
   description: Only build libraries, no programs.
   default: False
@@ -146,11 +150,14 @@ executable test-toxcore
   default-language: Haskell2010
   hs-source-dirs:   test/toxcore
   build-depends:    base < 5
+  extra-libraries:  sodium, pthread
   cc-options:
       -std=gnu99
       -Wall
       -- -Werror
-  extra-libraries:  sodium, pthread
+  if flag(asan)
+    cc-options: -fsanitize=address
+    ld-options: -fsanitize=address
   include-dirs:
       test/toxcore/msgpack-c/include
       test/toxcore/toxcore/toxcore


### PR DESCRIPTION
This will help identify problems while developing the C-libtoxcore test backend.

[1] http://clang.llvm.org/docs/AddressSanitizer.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/10)
<!-- Reviewable:end -->
