### PR TITLE
Fix "make repl".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ EXTRA_DIRS :=							\
 	--extra-include-dirs=$(HOME)/.cabal/extra-dist/include	\
 	--extra-lib-dirs=$(HOME)/.cabal/extra-dist/lib
 
+CONFIGURE_FLAGS :=		\
+	-fasan			\
+	--enable-benchmarks	\
+	--enable-tests		\
+	$(DISABLE_PROFILING)	\
+	$(EXTRA_DIRS)
+
+
 all: check $(DOCS)
 
 check: dist/hpc/tix/hstox/hstox.tix
@@ -42,7 +50,9 @@ dist/hpc/tix/hstox/hstox.tix: check-hstox check-toxcore
 check-%: .build.stamp
 	tools/run-tests $*
 
-repl: .build.stamp
+repl:
+	rm -f .configure.stamp
+	cabal configure $(CONFIGURE_FLAGS)
 	cabal repl
 
 clean:
@@ -66,8 +76,8 @@ test/toxcore/test_main-$(TEST): $(shell find test/toxcore -name "*.[ch]") test/t
 configure: .configure.stamp
 .configure.stamp: .libsodium.stamp
 	cabal update
-	cabal install --enable-tests $(EXTRA_DIRS) --only-dependencies hstox.cabal
-	cabal configure --enable-tests $(EXTRA_DIRS) $(ENABLE_COVERAGE) $(DISABLE_PROFILING)
+	cabal install $(CONFIGURE_FLAGS) --only-dependencies hstox.cabal
+	cabal configure $(CONFIGURE_FLAGS) $(ENABLE_COVERAGE)
 	@touch $@
 
 doc: $(DOCS)


### PR DESCRIPTION
cabal repl doesn't work well with HPC enabled, so we re-configure without
coverage before running the repl (read-eval-print-loop). We also delete
.configure.stamp so that next time we do "make build", we will re-configure
with coverage enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/17)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/TokTok/hstox/pull/17%23issuecomment-231329144%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/TokTok/hstox/pull/17%23issuecomment-231329144%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6921448/badge%29%5D%28https%3A//coveralls.io/builds/6921448%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A83a6c260d26c7492b3b6b5d16415b0a6cdf74f25%20on%20iphydf%3Afix-repl%2A%2A%20into%20%2A%2Acab577db52dc38191236ed53de6ac1a5e4d5558d%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T10%3A36%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/TokTok/hstox/pull/17#issuecomment-231329144'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6921448/badge)](https://coveralls.io/builds/6921448)
Coverage remained the same at 91.111% when pulling **83a6c260d26c7492b3b6b5d16415b0a6cdf74f25 on iphydf:fix-repl** into **cab577db52dc38191236ed53de6ac1a5e4d5558d on TokTok:master**.


<a href='https://www.codereviewhub.com/TokTok/hstox/pull/17?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/TokTok/hstox/pull/17?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/TokTok/hstox/pull/17'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>