### PR TITLE
Add hstox-remotes tool.

### DIFF
--- a/tools/hstox-remotes
+++ b/tools/hstox-remotes
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+
+use strict;
+use Data::Dumper;
+
+my %remotes = map { reverse ((split /\s+/)[0..1]) } `git remote -v`;
+
+sub add_remote {
+   my ($name, $repo) = @_;
+   system "git", "remote", "add", $name, $repo
+      unless $remotes{$repo};
+}
+
+sub repo { [$_[0], "git\@github.com:$_[0]/hstox"] }
+
+add_remote @$_ for (
+   ['upstream', 'git@github.com:toktok/hstox'],
+   repo 'iphydf',
+   repo 'piling',
+)


### PR DESCRIPTION
This tool adds all repositories owned by collaborators. The intended use is:
$ git clone git@github.com:$YOURNAME/hstox
$ cd hstox && tools/hstox-remotes

Using this, you will end up with "origin" being your own repo, "upstream" being
the toktok repo, and all other repos being named after their owner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/18)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/TokTok/hstox/pull/18%23issuecomment-231340234%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/TokTok/hstox/pull/18%23issuecomment-231340234%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6922237/badge%29%5D%28https%3A//coveralls.io/builds/6922237%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A16d55f451c777b4aa3b4a0cd32e1c3334f3113fd%20on%20iphydf%3Ahstox-remotes%2A%2A%20into%20%2A%2Acab577db52dc38191236ed53de6ac1a5e4d5558d%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T11%3A47%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/TokTok/hstox/pull/18#issuecomment-231340234'>General Comment</a></b>
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6922237/badge)](https://coveralls.io/builds/6922237)
Coverage remained the same at 91.111% when pulling **16d55f451c777b4aa3b4a0cd32e1c3334f3113fd on iphydf:hstox-remotes** into **cab577db52dc38191236ed53de6ac1a5e4d5558d on TokTok:master**.


<a href='https://www.codereviewhub.com/TokTok/hstox/pull/18?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/TokTok/hstox/pull/18?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/TokTok/hstox/pull/18'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>