### PR TITLE
MessagePack parser

### DIFF
--- a/hstox.cabal
+++ b/hstox.cabal
@@ -198,3 +198,19 @@ executable test-toxcore
       TestToxcore.hs
   if flag(library-only)
     buildable: False
+
+executable msgpack-parser
+  default-language: Haskell2010
+  hs-source-dirs:
+      tools/MessagePackParser
+  ghc-options:
+      -Wall
+      -Werror
+  build-depends:
+      base < 5
+    , bytestring
+    , hstox
+  main-is:
+      MessagePackParser.hs
+  if flag(library-only)
+    buildable: False

--- a/src/msgpack/Data/MessagePack/Object.hs
+++ b/src/msgpack/Data/MessagePack/Object.hs
@@ -49,7 +49,7 @@ data Object
   | ObjectExt    {-# UNPACK #-} !Word8 !S.ByteString
     -- ^ represents a tuple of an integer and a byte array where
     -- the integer represents type information and the byte array represents data.
-  deriving (Show, Eq, Ord, Typeable, Generic)
+  deriving (Read, Show, Eq, Ord, Typeable, Generic)
 
 instance NFData Object
 

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -36,15 +36,14 @@ module Main where
 import           Control.Applicative        ((<|>))
 import qualified Data.ByteString.Lazy       as L
 import qualified Data.ByteString.Lazy.Char8 as L8
-import           Data.Maybe                 (fromJust)
+import           Data.Maybe                 (fromMaybe)
 import           Data.MessagePack           (Object, pack, unpack)
 import           Text.Read                  (readMaybe)
 
 parse :: L.ByteString -> L.ByteString
-parse str = fromJust $
+parse str = fromMaybe L.empty $
   (pack <$> ((readMaybe . L8.unpack) str :: Maybe Object))
   <|> ((L8.pack . (flip (++) "\n") . show) <$> (unpack str :: Maybe Object))
-  <|> Just L.empty
 
 
 main :: IO ()

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -17,13 +17,19 @@
 -- No flags are required as it automatically detects which of these
 -- two functions it should perform.  This is done by first assuming
 -- the input is human readable.  If it fails to parse it, it then
--- considers it binary data.
+-- considers it as binary data.
 --
 -- Therefore, given a valid input, the tool has the following property
 --   $ cat input.bin | ./msgpack-parser | ./msgpack-parser
 -- will output back the contents of input.bin.
 --
 -- In case the input is impossible to parse, nothing is output.
+--
+-- Known bugs:
+--   - If no input is given, the tool exits with
+--     "Data.Binary.Get.runGet at position 0: not enough bytes"
+--   - The tool does not check that all the input is parsed.
+--     Therefore, "abc" is interpreted as just "ObjectInt 97".
 --
 module Main where
 

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -42,8 +42,8 @@ import           Text.Read                  (readMaybe)
 
 parse :: L.ByteString -> L.ByteString
 parse str = fromJust $
-  (pack <$> ((readMaybe.L8.unpack) str :: Maybe Object))
-  <|> ((L8.pack.(flip (++) "\n").show) <$> (unpack str :: Maybe Object))
+  (pack <$> ((readMaybe . L8.unpack) str :: Maybe Object))
+  <|> ((L8.pack . (flip (++) "\n") . show) <$> (unpack str :: Maybe Object))
   <|> Just L.empty
 
 

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE Safe #-}
+---------------------------
+--
+-- A MessagePack parser.
+--
+-- Example usage:
+--   $ echo -ne "\x94\x01\xa1\x32\xa1\x33\xa4\x50\x6f\x6f\x66" | ./msgpack-parser
+-- or
+--   $ echo 'ObjectArray [ObjectInt 97, ObjectStr "test",  ObjectBool True]' | ./msgpack-parser
+--
+-- This tool performs two symmetrical functions:
+--   1. It can decode binary data representing a
+--      Data.MessagePack.Object into a human-readable string.
+--   2. It can do the reverse: encode a human-readable string into
+--      a binary representation of Data.MessagePack.Object.
+--
+-- No flags are required as it automatically detects which of these
+-- two functions it should perform.  This is done by first assuming
+-- the input is human readable.  If it fails to parse it, it then
+-- considers it binary data.
+--
+-- Therefore, given a valid input, the tool has the following property
+--   $ cat input.bin | ./msgpack-parser | ./msgpack-parser
+-- will output back the contents of input.bin.
+--
+-- In case the input is impossible to parse, nothing is output.
+--
+module Main where
+
+import           Data.MessagePack           (pack, unpack, Object)
+import qualified Data.ByteString.Lazy       as L
+import qualified Data.ByteString.Lazy.Char8 as L8
+import           Text.Read                  (readMaybe)
+
+tryReadAsObject :: L.ByteString -> Maybe Object
+tryReadAsObject = readMaybe . L8.unpack
+
+tryUnpackAsObject :: L.ByteString -> Maybe Object
+tryUnpackAsObject = unpack
+
+parse :: L.ByteString -> L.ByteString
+parse bstr = case tryReadAsObject bstr of
+  Just o -> pack o
+  Nothing -> case tryUnpackAsObject bstr of
+    Just o -> L8.pack ((show o) ++ "\n")
+    Nothing -> L.empty
+
+main :: IO ()
+main = do
+  bytestring <- L8.getContents
+  L.putStr (parse bytestring)

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -43,7 +43,7 @@ import           Text.Read                  (readMaybe)
 parse :: L.ByteString -> L.ByteString
 parse str = fromMaybe L.empty $
   (pack <$> ((readMaybe . L8.unpack) str :: Maybe Object))
-  <|> ((L8.pack . (flip (++) "\n") . show) <$> (unpack str :: Maybe Object))
+  <|> ((L8.pack . flip (++) "\n" . show) <$> (unpack str :: Maybe Object))
 
 
 main :: IO ()


### PR DESCRIPTION
This tool provides a way to translate to and from msgpack Object. It essentially performs two kinds of conversions:
1. plaintext -> Data.MessagePack.Object -> BinaryString
2. BinaryString -> Data.MessagePackObject -> plaintext

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/22)
<!-- Reviewable:end -->
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/TokTok/hstox/pull/22%23issuecomment-231499163%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/22%23issuecomment-231499438%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/22%23issuecomment-231502107%22%2C%20%22https%3A//github.com/TokTok/hstox/pull/22%23discussion_r70158272%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/TokTok/hstox/pull/22%23issuecomment-231499163%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%5B%21%5BCLA%20assistant%20check%5D%28https%3A//cla-assistant.io/pull/badge/signed%29%5D%28https%3A//cla-assistant.io/TokTok/hstox%3FpullRequest%3D22%29%20%3Cbr/%3EAll%20committers%20have%20signed%20the%20CLA.%22%2C%20%22created_at%22%3A%20%222016-07-08T23%3A55%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11571300%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/CLAassistant%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5B%21%5BCoverage%20Status%5D%28https%3A//coveralls.io/builds/6932626/badge%29%5D%28https%3A//coveralls.io/builds/6932626%29%5Cn%5CnCoverage%20remained%20the%20same%20at%2091.111%25%20when%20pulling%20%2A%2A19b18b0aa6ba50c84c87c9bcbac93d182e1879d5%20on%20neduard%3Amsgpack-parser%2A%2A%20into%20%2A%2Acab577db52dc38191236ed53de6ac1a5e4d5558d%20on%20TokTok%3Amaster%2A%2A.%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-08T23%3A58%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/2354108%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/coveralls%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5Cn%5Cn%5Cn%5CnReview%20status%3A%200%20of%203%20files%20reviewed%20at%20latest%20revision%2C%202%20unresolved%20discussions.%5Cn%5Cn---%5Cn%5Cn%2A%5Btools/MessagePackParser/MessagePackParser.hs%2C%20line%2042%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/22%23-KMC09Y6gEuNirCIZPIE%3A-KMC-aYiiEkhkr1I_JHj%3A845244049%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/19b18b0aa6ba50c84c87c9bcbac93d182e1879d5/tools/MessagePackParser/MessagePackParser.hs%23L42%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%5Cn%3E%20parse%20%3A%3A%20L.ByteString%20-%3E%20L.ByteString%5Cn%3E%20parse%20bstr%20%3D%20case%20tryReadAsObject%20bstr%20of%5Cn%3E%20%60%60%60%5Cn%5CnThis%20function%20can%20be%20a%20lot%20shorter%20using%20%3C%24%3E%20and%20%3C%7C%3E.%20It%27s%20an%20excellent%20opportunity%20to%20use%20the%20applicative%20operators.%5Cn%5Cn---%5Cn%5Cn%2A%5Btools/MessagePackParser/MessagePackParser.hs%2C%20line%2049%20%5C%5C%5Br1%5C%5C%5D%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/22%23-KMC1WkJ5HHN73bqHG60%3A-KMC0T8nhDcZUJ_8XbSU%3A-1132979023%29%20%28%5Braw%20file%5D%28https%3A//github.com/toktok/hstox/blob/19b18b0aa6ba50c84c87c9bcbac93d182e1879d5/tools/MessagePackParser/MessagePackParser.hs%23L49%29%29%3A%2A%5Cn%3E%20%60%60%60Haskell%5Cn%3E%20%5Cn%3E%20main%20%3A%3A%20IO%20%28%29%5Cn%3E%20main%20%3D%20do%5Cn%3E%20%60%60%60%5Cn%5Cnparse%20%3C%24%3E%20L8.getContents%20%3E%3E%3D%20L.putStr%5CnOr%5CnL.putStr%20%3D%3C%3C%20...%5Cnhttp%3A//hackage.haskell.org/package/base-4.9.0.0/docs/Prelude.html%23v%3A-61--60--60-%5Cn%5Cn---%5Cn%5Cn%5Cn%2AComments%20from%20%5BReviewable%5D%28https%3A//reviewable.io%3A443/reviews/toktok/hstox/22%29%2A%5Cn%3C%21--%20Sent%20from%20Reviewable.io%20--%3E%5Cn%22%2C%20%22created_at%22%3A%20%222016-07-09T00%3A24%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10647936%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iphydf%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2019b18b0aa6ba50c84c87c9bcbac93d182e1879d5%20tools/MessagePackParser/MessagePackParser.hs%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/TokTok/hstox/pull/22%23discussion_r70158272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Run%20stylish-haskell%20on%20this%20code.%20%21fix%20%20%21fix%22%2C%20%22created_at%22%3A%20%222016-07-09T00%3A37%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10647936%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/iphydf%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tools/MessagePackParser/MessagePackParser.hs%3AL1-52%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/TokTok/hstox/pull/22#issuecomment-231499163'>General Comment</a></b>
- <a href='https://github.com/CLAassistant'><img border=0 src='https://avatars.githubusercontent.com/u/11571300?v=3' height=16 width=16'></a> [![CLA assistant check](https://cla-assistant.io/pull/badge/signed)](https://cla-assistant.io/TokTok/hstox?pullRequest=22) <br/>All committers have signed the CLA.
- <a href='https://github.com/coveralls'><img border=0 src='https://avatars.githubusercontent.com/u/2354108?v=3' height=16 width=16'></a> [![Coverage Status](https://coveralls.io/builds/6932626/badge)](https://coveralls.io/builds/6932626)
Coverage remained the same at 91.111% when pulling **19b18b0aa6ba50c84c87c9bcbac93d182e1879d5 on neduard:msgpack-parser** into **cab577db52dc38191236ed53de6ac1a5e4d5558d on TokTok:master**.
- <a href='https://github.com/iphydf'><img border=0 src='https://avatars.githubusercontent.com/u/10647936?v=3' height=16 width=16'></a> Review status: 0 of 3 files reviewed at latest revision, 2 unresolved discussions.
---
*[tools/MessagePackParser/MessagePackParser.hs, line 42 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/22#-KMC09Y6gEuNirCIZPIE:-KMC-aYiiEkhkr1I_JHj:845244049) ([raw file](https://github.com/toktok/hstox/blob/19b18b0aa6ba50c84c87c9bcbac93d182e1879d5/tools/MessagePackParser/MessagePackParser.hs#L42)):*
> ```Haskell
>
> parse :: L.ByteString -> L.ByteString
> parse bstr = case tryReadAsObject bstr of
> ```
This function can be a lot shorter using <$> and <|>. It's an excellent opportunity to use the applicative operators.
---
*[tools/MessagePackParser/MessagePackParser.hs, line 49 \[r1\]](https://reviewable.io:443/reviews/toktok/hstox/22#-KMC1WkJ5HHN73bqHG60:-KMC0T8nhDcZUJ_8XbSU:-1132979023) ([raw file](https://github.com/toktok/hstox/blob/19b18b0aa6ba50c84c87c9bcbac93d182e1879d5/tools/MessagePackParser/MessagePackParser.hs#L49)):*
> ```Haskell
>
> main :: IO ()
> main = do
> ```
parse <$> L8.getContents >>= L.putStr
Or
L.putStr =<< ...
http://hackage.haskell.org/package/base-4.9.0.0/docs/Prelude.html#v:-61--60--60-
---
*Comments from [Reviewable](https://reviewable.io:443/reviews/toktok/hstox/22)*
<!-- Sent from Reviewable.io -->
- [ ] <a href='#crh-comment-Pull 19b18b0aa6ba50c84c87c9bcbac93d182e1879d5 tools/MessagePackParser/MessagePackParser.hs 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/TokTok/hstox/pull/22#discussion_r70158272'>File: tools/MessagePackParser/MessagePackParser.hs:L1-52</a></b>
- <a href='https://github.com/iphydf'><img border=0 src='https://avatars.githubusercontent.com/u/10647936?v=3' height=16 width=16'></a> Run stylish-haskell on this code. !fix  !fix


<a href='https://www.codereviewhub.com/TokTok/hstox/pull/22?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/TokTok/hstox/pull/22?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/TokTok/hstox/pull/22'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>