### PR TITLE
Add timeout to the test driver.

### DIFF
--- a/test/toxcore/driver.c
+++ b/test/toxcore/driver.c
@@ -21,7 +21,7 @@
 static void
 handle_interrupt (int signum)
 {
-  puts ("Caught interrupt; exiting cleanly.");
+  printf ("Caught signal %d; exiting cleanly.", signum);
   exit (0);
 }
 
@@ -214,10 +214,15 @@ run_tests (struct settings cfg, int port)
 
 
 uint32_t
-network_main (struct settings cfg, uint16_t port)
+network_main (struct settings cfg, uint16_t port, unsigned int timeout)
 {
+  signal (SIGALRM, handle_interrupt);
   signal (SIGINT, handle_interrupt);
   check_return (E_SODIUM, sodium_init ());
+
+  // Kill the process after `timeout` seconds so we don't get lingering
+  // processes bound to the test port when something goes wrong with a test run.
+  alarm (timeout);
 
   int result = run_tests (cfg, port);
   if (result == E_OK)

--- a/test/toxcore/driver.h
+++ b/test/toxcore/driver.h
@@ -18,4 +18,4 @@ struct settings
 int communicate (struct settings cfg, int read_fd, int write_fd);
 
 // Open a TCP socket on the given port and start communicate().
-uint32_t network_main (struct settings cfg, uint16_t port);
+uint32_t network_main (struct settings cfg, uint16_t port, unsigned int timeout);

--- a/test/toxcore/test_main.c
+++ b/test/toxcore/test_main.c
@@ -8,6 +8,11 @@
 // The msgpack-rpc test port expected by the test runner.
 #define PORT 1234
 
+// Timeout in seconds after which the driver shuts down. Currently, a complete
+// test run takes about 7 seconds. The timeout of 2 minutes is a guess so it
+// keeps working for a while, even on a very slow computer.
+#define TIMEOUT 120
+
 
 static char const *
 error_desc (int code)
@@ -35,7 +40,7 @@ int
 main (void)
 {
   struct settings cfg = { true, true };
-  uint32_t result = network_main (cfg, PORT);
+  uint32_t result = network_main (cfg, PORT, TIMEOUT);
   int line  =  result >> 16;
   int error = (result >>  8) & 0xff;
   int code  =  result        & 0xff;


### PR DESCRIPTION
@piling had issues with running new tests because the old test driver was still
running and taking up a port. This commit makes sure that it can only happen for
2 minutes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/29)
<!-- Reviewable:end -->
