### PR TITLE
Add missing "\n" in toxcore/driver.c where it used to use puts.

### DIFF
--- a/test/toxcore/driver.c
+++ b/test/toxcore/driver.c
@@ -21,7 +21,7 @@
 static void
 handle_interrupt (int signum)
 {
-  printf ("Caught signal %d; exiting cleanly.", signum);
+  printf ("Caught signal %d; exiting cleanly.\n", signum);
   exit (0);
 }
 


### PR DESCRIPTION
`puts` writes a newline, `printf` doesn't. I missed adding that newline when I
changed it to print the signal number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/31)
<!-- Reviewable:end -->
