### PR TITLE
Check types in DISPATCH, not in each encoding method.

### DIFF
--- a/test/toxcore/binary_decode.c
+++ b/test/toxcore/binary_decode.c
@@ -40,9 +40,9 @@ METHOD (bin, Binary_decode, TransportProtocol) { return pending; }
 
 METHOD (array, Binary, decode)
 {
-  CHECK (args.size == 2);
-  CHECK (args.ptr[0].type == MSGPACK_OBJECT_STR);
-  CHECK (args.ptr[1].type == MSGPACK_OBJECT_BIN);
+  CHECK_SIZE (args, 2);
+  CHECK_TYPE (args.ptr[0], MSGPACK_OBJECT_STR);
+  CHECK_TYPE (args.ptr[1], MSGPACK_OBJECT_BIN);
 
   msgpack_object_str type = args.ptr[0].via.str;
 #define DISPATCH(TYPE) \

--- a/test/toxcore/binary_encode.c
+++ b/test/toxcore/binary_encode.c
@@ -1,26 +1,23 @@
 #include "methods.h"
 
-METHOD (array, Binary_encode, CipherText) { return pending; }
+
+METHOD (bin, Binary_encode, CipherText) { return pending; }
 METHOD (array, Binary_encode, DhtPacket) { return pending; }
 METHOD (array, Binary_encode, HostAddress) { return pending; }
-METHOD (array, Binary_encode, Int) { return pending; }
-METHOD (array, Binary_encode, Key) { return pending; }
+METHOD (u64, Binary_encode, Int) { return pending; }
+METHOD (bin, Binary_encode, Key) { return pending; }
 
 METHOD (array, Binary_encode, KeyPair)
 {
-  CHECK (args.ptr[1].type == MSGPACK_OBJECT_ARRAY);
+  CHECK_SIZE (args, 2);
+  CHECK_TYPE (args.ptr[0], MSGPACK_OBJECT_BIN);
+  CHECK_TYPE (args.ptr[1], MSGPACK_OBJECT_BIN);
 
-  msgpack_object_array key_pair = args.ptr[1].via.array;
+  msgpack_object_bin secret_key = args.ptr[0].via.bin;
+  msgpack_object_bin public_key = args.ptr[1].via.bin;
 
-  CHECK (key_pair.size == 2);
-  CHECK (key_pair.ptr[0].type == MSGPACK_OBJECT_BIN);
-  CHECK (key_pair.ptr[1].type == MSGPACK_OBJECT_BIN);
-
-  msgpack_object_bin secret_key = key_pair.ptr[0].via.bin;
-  msgpack_object_bin public_key = key_pair.ptr[1].via.bin;
-
-  CHECK (secret_key.size == 32);
-  CHECK (public_key.size == 32);
+  CHECK_SIZE (secret_key, 32);
+  CHECK_SIZE (public_key, 32);
 
   SUCCESS {
     uint8_t data[64];
@@ -34,45 +31,49 @@ METHOD (array, Binary_encode, KeyPair)
 }
 
 METHOD (array, Binary_encode, NodeInfo) { return pending; }
-METHOD (array, Binary_encode, NodesRequest) { return pending; }
+METHOD (bin, Binary_encode, NodesRequest) { return pending; }
 METHOD (array, Binary_encode, NodesResponse) { return pending; }
 METHOD (array, Binary_encode, Packet) { return pending; }
-METHOD (array, Binary_encode, PacketKind) { return pending; }
-METHOD (array, Binary_encode, PingPacket) { return pending; }
-METHOD (array, Binary_encode, PlainText) { return pending; }
-METHOD (array, Binary_encode, PortNumber) { return pending; }
+METHOD (u64, Binary_encode, PacketKind) { return pending; }
+METHOD (u64, Binary_encode, PingPacket) { return pending; }
+METHOD (bin, Binary_encode, PlainText) { return pending; }
+METHOD (u64, Binary_encode, PortNumber) { return pending; }
 METHOD (array, Binary_encode, RpcPacket) { return pending; }
 METHOD (array, Binary_encode, SocketAddress) { return pending; }
-METHOD (array, Binary_encode, TransportProtocol) { return pending; }
+METHOD (u64, Binary_encode, TransportProtocol) { return pending; }
 
 
 METHOD (array, Binary, encode)
 {
-  CHECK (args.size == 2);
-  CHECK (args.ptr[0].type == MSGPACK_OBJECT_STR);
+  CHECK_SIZE (args, 2);
+  CHECK_TYPE (args.ptr[0], MSGPACK_OBJECT_STR);
 
   msgpack_object_str type = args.ptr[0].via.str;
-#define DISPATCH(TYPE) \
+#define DISPATCH(TYPE, UTYPE, LTYPE) do { \
   if (type.size == sizeof #TYPE - 1 && \
       memcmp (type.ptr, #TYPE, type.size) == 0) \
-    return Binary_encode_##TYPE (args, res)
-  DISPATCH (CipherText);
-  DISPATCH (DhtPacket);
-  DISPATCH (HostAddress);
-  DISPATCH (Int);
-  DISPATCH (Key);
-  DISPATCH (KeyPair);
-  DISPATCH (NodeInfo);
-  DISPATCH (NodesRequest);
-  DISPATCH (NodesResponse);
-  DISPATCH (Packet);
-  DISPATCH (PacketKind);
-  DISPATCH (PingPacket);
-  DISPATCH (PlainText);
-  DISPATCH (PortNumber);
-  DISPATCH (RpcPacket);
-  DISPATCH (SocketAddress);
-  DISPATCH (TransportProtocol);
+    { \
+      CHECK_TYPE (args.ptr[1], MSGPACK_OBJECT_##UTYPE); \
+      return Binary_encode_##TYPE (args.ptr[1].via.LTYPE, res); \
+    } \
+} while (0)
+  DISPATCH (CipherText       , BIN             , bin);
+  DISPATCH (DhtPacket        , ARRAY           , array);
+  DISPATCH (HostAddress      , ARRAY           , array);
+  DISPATCH (Int              , POSITIVE_INTEGER, u64);
+  DISPATCH (Key              , BIN             , bin);
+  DISPATCH (KeyPair          , ARRAY           , array);
+  DISPATCH (NodeInfo         , ARRAY           , array);
+  DISPATCH (NodesRequest     , BIN             , bin);
+  DISPATCH (NodesResponse    , ARRAY           , array);
+  DISPATCH (Packet           , ARRAY           , array);
+  DISPATCH (PacketKind       , POSITIVE_INTEGER, u64);
+  DISPATCH (PingPacket       , POSITIVE_INTEGER, u64);
+  DISPATCH (PlainText        , BIN             , bin);
+  DISPATCH (PortNumber       , POSITIVE_INTEGER, u64);
+  DISPATCH (RpcPacket        , ARRAY           , array);
+  DISPATCH (SocketAddress    , ARRAY           , array);
+  DISPATCH (TransportProtocol, POSITIVE_INTEGER, u64);
 #undef DISPATCH
 
   return unimplemented;

--- a/test/toxcore/methods.c
+++ b/test/toxcore/methods.c
@@ -48,9 +48,9 @@ METHOD (array, KeyPair, newKeyPair)
 
 METHOD (array, KeyPair, fromSecretKey)
 {
-  CHECK (args.size == 1);
-  CHECK (args.ptr[0].type == MSGPACK_OBJECT_BIN);
-  CHECK (args.ptr[0].via.bin.size == crypto_box_SECRETKEYBYTES);
+  CHECK_SIZE (args, 1);
+  CHECK_TYPE (args.ptr[0], MSGPACK_OBJECT_BIN);
+  CHECK_SIZE (args.ptr[0].via.bin, crypto_box_SECRETKEYBYTES);
 
   Net_Crypto c;
   uint8_t secret_key[crypto_box_SECRETKEYBYTES];
@@ -85,9 +85,9 @@ METHOD (array, Nonce, newNonce)
 
 METHOD (array, Nonce, increment)
 {
-  CHECK (args.size == 1);
-  CHECK (args.ptr[0].type == MSGPACK_OBJECT_BIN);
-  CHECK (args.ptr[0].via.bin.size == 24);
+  CHECK_SIZE (args, 1);
+  CHECK_TYPE (args.ptr[0], MSGPACK_OBJECT_BIN);
+  CHECK_SIZE (args.ptr[0].via.bin, 24);
 
   uint8_t nonce[24];
   memcpy (nonce, args.ptr[0].via.bin.ptr, 24);

--- a/test/toxcore/methods.h
+++ b/test/toxcore/methods.h
@@ -1,16 +1,42 @@
 #pragma once
 
+#include "util.h"
+
 #include <msgpack.h>
 
-#define CHECK(cond) if (!(cond)) return #cond
+
+#define CHECK(COND) do { if (!(COND)) return #COND; } while (0)
+
+#define CHECK_SIZE(ARG, SIZE) do { \
+  if ((ARG).size != (SIZE)) \
+    return ssprintf ("Size of `" #ARG "' expected to be %zu, but was %zu", \
+                     SIZE, (ARG).size); \
+} while (0)
+
+#define CHECK_TYPE(ARG, TYPE) do { \
+  if ((ARG).type != (TYPE)) \
+    return ssprintf ("Type of `" #ARG "' expected to be %s, but was %s", \
+                     type_name (TYPE), type_name ((ARG).type)); \
+} while (0)
+
+
 #define SUCCESS msgpack_pack_array (res, 0); if (true)
+
 
 #define METHOD(TYPE, SERVICE, NAME) \
 char const * \
 SERVICE##_##NAME (msgpack_object_##TYPE args, msgpack_packer *res)
 
+
+// These are not defined by msgpack.h, but we need them for uniformity in the
+// METHOD macro.
+typedef int64_t msgpack_object_i64;
+typedef uint64_t msgpack_object_u64;
+
+
 METHOD (array, Binary, decode);
 METHOD (array, Binary, encode);
+
 
 char const *call_method (msgpack_object_str name, msgpack_object_array args, msgpack_packer *res);
 

--- a/test/toxcore/util.c
+++ b/test/toxcore/util.c
@@ -50,3 +50,16 @@ msgpack_pack_stringf (msgpack_packer *pk, char const *fmt, ...)
   va_end (ap);
   return res;
 }
+
+
+char const *
+ssprintf (char const *fmt, ...)
+{
+  static char buf[1024];
+
+  va_list ap;
+  va_start (ap, fmt);
+  vsnprintf (buf, sizeof buf, fmt, ap);
+  va_end (ap);
+  return buf;
+}

--- a/test/toxcore/util.h
+++ b/test/toxcore/util.h
@@ -18,6 +18,9 @@
 
 char const *type_name (msgpack_object_type type);
 
+// Statically allocated "asprintf".
+char const *ssprintf (char const *fmt, ...);
+
 int msgpack_pack_string (msgpack_packer *pk, char const *str);
 int msgpack_pack_stringf (msgpack_packer *pk, char const *fmt, ...);
 int msgpack_pack_vstringf (msgpack_packer *pk, char const *fmt, va_list ap);


### PR DESCRIPTION
Originally, the encoding method would have to check, and it received the whole
arguments array. This is counter-intuitive, because it already knows the type,
as it has just been called due to it. Now, only the argument itself is passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/34)
<!-- Reviewable:end -->
