### PR TITLE
Update the hash in install-libsodium *after* installing.

### DIFF
--- a/tools/install-libsodium
+++ b/tools/install-libsodium
@@ -16,7 +16,8 @@ if diff new-hash $HOME/.cabal/extra-dist/libsodium.hash; then
 fi
 
 echo "Hashes differ => rebuilding"
-mv new-hash $HOME/.cabal/extra-dist/libsodium.hash
 sh autogen.sh
 ./configure --prefix=$HOME/.cabal/extra-dist
 make install
+
+mv new-hash $HOME/.cabal/extra-dist/libsodium.hash


### PR DESCRIPTION
Otherwise, configure/make install failure will prevent future attempts to
install libsodium, thus later possibly failing the build of haskell saltine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/36)
<!-- Reviewable:end -->
