### PR TITLE
Remove unused imports; pretty-print msgpack-parser output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 # Test flavour. See test/toxcore/Makefile for choices.
 TEST	:= vanilla
 
-SOURCES	:= $(shell find src test -name "*.*hs" -or -name "*.c" -or -name "*.h")
+SOURCES	:= $(shell find src test tools -name "*.*hs" -or -name "*.c" -or -name "*.h")
 
 ifneq ($(wildcard ../tox-spec/pandoc.mk),)
 ifneq ($(shell which pandoc),)
@@ -24,6 +24,8 @@ DOCS	:= ../tox-spec/spec.md
 include ../tox-spec/pandoc.mk
 endif
 endif
+
+export LD_LIBRARY_PATH := $(HOME)/.cabal/extra-dist/lib
 
 EXTRA_DIRS :=							\
 	--extra-include-dirs=$(HOME)/.cabal/extra-dist/include	\

--- a/hstox.cabal
+++ b/hstox.cabal
@@ -27,9 +27,10 @@ library
     , src/tox
   ghc-options:
       -Wall
+      -fno-warn-unused-imports
   build-depends:
       base < 5
-    , QuickCheck
+    , QuickCheck >= 2.9.1
     , base16-bytestring
     , binary
     , binary-bits
@@ -54,7 +55,6 @@ library
     , text
     , transformers
     , unordered-containers
-    , vector
   other-modules:
       Data.MessagePack.Assoc
       Data.MessagePack.Class
@@ -102,6 +102,7 @@ executable testsuite
       src/testsuite
   ghc-options:
       -Wall
+      -fno-warn-unused-imports
   build-depends:
       base < 5
     , QuickCheck
@@ -117,6 +118,7 @@ executable testsuite
     , mtl
     , network
     , saltine
+    , tagged
     , text
     , transformers
     , unordered-containers
@@ -131,6 +133,7 @@ executable test-hstox
       test/hstox
   ghc-options:
       -Wall
+      -fno-warn-unused-imports
   build-depends:
       base < 5
     , hstox
@@ -145,9 +148,11 @@ executable msgpack-parser
       tools/MessagePackParser
   ghc-options:
       -Wall
+      -fno-warn-unused-imports
   build-depends:
       base < 5
     , bytestring
+    , groom
     , hstox
   main-is:
       MessagePackParser.hs

--- a/src/msgpack/Data/MessagePack/Assoc.hs
+++ b/src/msgpack/Data/MessagePack/Assoc.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Trustworthy                #-}

--- a/src/msgpack/Data/MessagePack/Generic.hs
+++ b/src/msgpack/Data/MessagePack/Generic.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE IncoherentInstances #-}
@@ -10,7 +9,7 @@
 {-# LANGUAGE TypeOperators       #-}
 module Data.MessagePack.Generic () where
 
-import           Control.Applicative     (Applicative, (<$>), (<*>), (<|>))
+import           Control.Applicative     (Applicative, (<$>), (<*>))
 import           Control.Monad           ((>=>))
 import           Data.Bits               (shiftR)
 import           Data.Word               (Word64)
@@ -53,7 +52,7 @@ instance MessagePack a => GMessagePack (K1 i a) where
 
 class GProdPack f where
   prodToObject :: f a -> [Object]
-  prodFromObject :: (Functor m, Applicative m, Monad m) => [Object] -> m (f a)
+  prodFromObject :: (Applicative m, Monad m) => [Object] -> m (f a)
 
 
 instance (GMessagePack a, GProdPack b) => GProdPack (a :*: b) where
@@ -69,13 +68,13 @@ instance GMessagePack a => GProdPack (M1 t c a) where
 
 -- Sum type packing.
 
-checkSumFromObject0 :: (Functor m, Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> m (f a)
+checkSumFromObject0 :: (Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> m (f a)
 checkSumFromObject0 size code
   | code < size = sumFromObject code size ObjectNil
   | otherwise   = fail "unknown encoding for constructor"
 
 
-checkSumFromObject :: (Functor m, Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> Object -> m (f a)
+checkSumFromObject :: (Applicative m, Monad m) => (GSumPack f) => Word64 -> Word64 -> Object -> m (f a)
 checkSumFromObject size code x
   | code < size = sumFromObject code size x
   | otherwise   = fail "unknown encoding for constructor"
@@ -83,7 +82,7 @@ checkSumFromObject size code x
 
 class GSumPack f where
   sumToObject :: Word64 -> Word64 -> f a -> Object
-  sumFromObject :: (Functor m, Applicative m, Monad m) => Word64 -> Word64 -> Object -> m (f a)
+  sumFromObject :: (Applicative m, Monad m) => Word64 -> Word64 -> Object -> m (f a)
 
 
 instance (GSumPack a, GSumPack b) => GSumPack (a :+: b) where

--- a/src/msgpack/Data/MessagePack/Object.hs
+++ b/src/msgpack/Data/MessagePack/Object.hs
@@ -1,9 +1,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE LambdaCase         #-}
-{-# LANGUAGE Trustworthy        #-}
+{-# LANGUAGE Safe               #-}
 module Data.MessagePack.Object (Object (..)) where
 
 import           Control.Applicative       ((<$), (<$>), (<*>), (<|>))
@@ -15,7 +14,6 @@ import           Data.Int                  (Int64)
 import qualified Data.Text                 as T
 import qualified Data.Text.Lazy            as LT
 import           Data.Typeable             (Typeable)
-import qualified Data.Vector               as V
 import           Data.Word                 (Word8)
 import           GHC.Generics              (Generic)
 import           Prelude                   hiding (putStr)
@@ -42,9 +40,9 @@ data Object
     -- ^ extending Raw type represents a UTF-8 string
   | ObjectBin                   !S.ByteString
     -- ^ extending Raw type represents a byte array
-  | ObjectArray                 !(V.Vector Object)
+  | ObjectArray                 ![Object]
     -- ^ represents a sequence of objects
-  | ObjectMap                   !(V.Vector (Object, Object))
+  | ObjectMap                   ![(Object, Object)]
     -- ^ represents key-value pairs of objects
   | ObjectExt    {-# UNPACK #-} !Word8 !S.ByteString
     -- ^ represents a tuple of an integer and a byte array where
@@ -110,6 +108,3 @@ instance Arbitrary T.Text where
 
 instance Arbitrary LT.Text where
   arbitrary = LT.pack <$> arbitrary
-
-instance Arbitrary v => Arbitrary (V.Vector v) where
-  arbitrary = V.fromList <$> arbitrary

--- a/src/msgpack/Data/MessagePack/Put.hs
+++ b/src/msgpack/Data/MessagePack/Put.hs
@@ -35,7 +35,6 @@ import qualified Data.ByteString     as S
 import           Data.Int            (Int64)
 import qualified Data.Text           as T
 import qualified Data.Text.Encoding  as T
-import qualified Data.Vector         as V
 import           Data.Word           (Word8)
 
 import           Prelude             hiding (putStr)
@@ -103,27 +102,27 @@ putBin bs = do
           putWord8 0xC6 >> putWord32be (fromIntegral len)
   putByteString bs
 
-putArray :: (a -> Put) -> V.Vector a -> Put
+putArray :: (a -> Put) -> [a] -> Put
 putArray p xs = do
-  case V.length xs of
+  case length xs of
     len | len <= 15 ->
           putWord8 $ 0x90 .|. fromIntegral len
         | len < 0x10000 ->
           putWord8 0xDC >> putWord16be (fromIntegral len)
         | otherwise ->
           putWord8 0xDD >> putWord32be (fromIntegral len)
-  V.mapM_ p xs
+  mapM_ p xs
 
-putMap :: (a -> Put) -> (b -> Put) -> V.Vector (a, b) -> Put
+putMap :: (a -> Put) -> (b -> Put) -> [(a, b)] -> Put
 putMap p q xs = do
-  case V.length xs of
+  case length xs of
     len | len <= 15 ->
           putWord8 $ 0x80 .|. fromIntegral len
         | len < 0x10000 ->
           putWord8 0xDE >> putWord16be (fromIntegral len)
         | otherwise ->
           putWord8 0xDF >> putWord32be (fromIntegral len)
-  V.mapM_ (\(a, b) -> p a >> q b ) xs
+  mapM_ (\(a, b) -> p a >> q b) xs
 
 putExt :: Word8 -> S.ByteString -> Put
 putExt typ dat = do

--- a/src/msgpack/Network/MessagePack/Client.hs
+++ b/src/msgpack/Network/MessagePack/Client.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE Trustworthy                #-}

--- a/src/msgpack/Network/MessagePack/Server.hs
+++ b/src/msgpack/Network/MessagePack/Server.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}

--- a/src/testsuite/Network/Tox/BinarySpec.hs
+++ b/src/testsuite/Network/Tox/BinarySpec.hs
@@ -1,16 +1,12 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.BinarySpec where
 
-import           Control.Monad.IO.Class (liftIO)
-import           Network.Tox.RPC        (runClient)
 import           Test.Hspec
-import           Test.QuickCheck
 
-import           Data.Proxy             (Proxy (..))
+import           Data.Proxy         (Proxy (..))
 
-import qualified Network.Tox.Binary     as Binary
-import qualified Network.Tox.RPC        as RPC
+import qualified Network.Tox.Binary as Binary
+import qualified Network.Tox.RPC    as RPC
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/Crypto/CombinedKeySpec.hs
+++ b/src/testsuite/Network/Tox/Crypto/CombinedKeySpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.CombinedKeySpec where
 

--- a/src/testsuite/Network/Tox/Crypto/KeyPairSpec.hs
+++ b/src/testsuite/Network/Tox/Crypto/KeyPairSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.KeyPairSpec where
 

--- a/src/testsuite/Network/Tox/Crypto/KeySpec.hs
+++ b/src/testsuite/Network/Tox/Crypto/KeySpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.KeySpec where
 

--- a/src/testsuite/Network/Tox/Crypto/NonceSpec.hs
+++ b/src/testsuite/Network/Tox/Crypto/NonceSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.NonceSpec where
 
@@ -7,11 +6,7 @@ import           Network.Tox.RPCTest      (equivProp1, runTest)
 import           Test.Hspec
 import           Test.QuickCheck
 
-import           Control.Applicative      ((<$>))
-import           Control.Monad            (unless)
-import           Network.Tox.Crypto.Key   (Nonce)
 import qualified Network.Tox.Crypto.Nonce as Nonce
-import           System.Environment       (lookupEnv)
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/Crypto/TextSpec.hs
+++ b/src/testsuite/Network/Tox/Crypto/TextSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Trustworthy         #-}
 module Network.Tox.Crypto.TextSpec where
@@ -11,6 +10,7 @@ import           Data.Proxy               (Proxy (..))
 import           Network.Tox.Crypto.Text  (CipherText, PlainText (..))
 import qualified Network.Tox.Crypto.Text  as Text
 import           Network.Tox.EncodingSpec
+import           Test.Result
 
 
 spec :: Spec
@@ -26,10 +26,7 @@ spec = do
     property $ \(bytes :: String) ->
       Text.decode (Text.encode bytes) `shouldBe` Just bytes
 
-  {-
   it "should return an error message in a monad that supports fail" $
     case Text.decode (PlainText (ByteString.pack [0x00])) of
-      Test.Skipped         -> expectationFailure   "Expected failure, but got Skipped"
-      Test.Success success -> expectationFailure $ "Expected failure, but got Success: " ++ success
-      Test.Failure failure -> failure `shouldContain` "not enough bytes"
-  -}
+      TestSuccess success -> expectationFailure $ "Expected failure, but got success: " ++ success
+      TestFailure failure -> failure `shouldContain` "not enough bytes"

--- a/src/testsuite/Network/Tox/CryptoSpec.hs
+++ b/src/testsuite/Network/Tox/CryptoSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.CryptoSpec where
 

--- a/src/testsuite/Network/Tox/DHT/DhtPacketSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/DhtPacketSpec.hs
@@ -1,13 +1,12 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.DhtPacketSpec where
 
 import           Test.Hspec
 import           Test.QuickCheck
 
-import           Data.Binary                   (Binary, get, put)
+import           Data.Binary                   (Binary)
 import qualified Data.Binary                   as Binary (get, put)
-import qualified Data.Binary.Get               as Binary (Get, runGet)
+import qualified Data.Binary.Get               as Binary (runGet)
 import qualified Data.Binary.Put               as Binary (runPut)
 import           Data.Proxy                    (Proxy (..))
 import           Network.Tox.Crypto.Key        (Nonce)

--- a/src/testsuite/Network/Tox/DHT/DhtStateSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/DhtStateSpec.hs
@@ -1,8 +1,6 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.DhtStateSpec where
 
-import           Debug.Trace
 import           Test.Hspec
 import           Test.QuickCheck
 
@@ -12,7 +10,6 @@ import           Data.Proxy                    (Proxy (..))
 import qualified Network.Tox.Crypto.KeyPair    as KeyPair
 import           Network.Tox.DHT.DhtState      (DhtState)
 import qualified Network.Tox.DHT.DhtState      as DhtState
-import qualified Network.Tox.DHT.KBuckets      as KBuckets
 import           Network.Tox.EncodingSpec
 import qualified Network.Tox.NodeInfo.NodeInfo as NodeInfo
 

--- a/src/testsuite/Network/Tox/DHT/DistanceSpec.lhs
+++ b/src/testsuite/Network/Tox/DHT/DistanceSpec.lhs
@@ -1,5 +1,4 @@
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE LambdaCase  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.DistanceSpec where

--- a/src/testsuite/Network/Tox/DHT/KBucketsSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/KBucketsSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE LambdaCase  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.KBucketsSpec where
@@ -9,7 +8,6 @@ import           Test.QuickCheck
 import           Control.Monad                 (when)
 import qualified Data.Map                      as Map
 import           Data.Proxy                    (Proxy (..))
-import qualified Data.Set                      as Set
 import           Network.Tox.Crypto.Key        (PublicKey)
 import qualified Network.Tox.DHT.Distance      as Distance
 import           Network.Tox.DHT.KBuckets      (KBuckets)

--- a/src/testsuite/Network/Tox/DHT/NodesRequestSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/NodesRequestSpec.hs
@@ -1,13 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.NodesRequestSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                   (Proxy (..))
 import           Network.Tox.DHT.NodesRequest (NodesRequest)
-import qualified Network.Tox.DHT.NodesRequest as NodesRequest
 import           Network.Tox.EncodingSpec
 
 

--- a/src/testsuite/Network/Tox/DHT/NodesResponseSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/NodesResponseSpec.hs
@@ -1,13 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.NodesResponseSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                    (Proxy (..))
 import           Network.Tox.DHT.NodesResponse (NodesResponse)
-import qualified Network.Tox.DHT.NodesResponse as NodesResponse
 import           Network.Tox.EncodingSpec
 
 

--- a/src/testsuite/Network/Tox/DHT/PingPacketSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/PingPacketSpec.hs
@@ -1,13 +1,10 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.PingPacketSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                 (Proxy (..))
 import           Network.Tox.DHT.PingPacket (PingPacket)
-import qualified Network.Tox.DHT.PingPacket as PingPacket
 import           Network.Tox.EncodingSpec
 
 

--- a/src/testsuite/Network/Tox/DHT/RpcPacketSpec.hs
+++ b/src/testsuite/Network/Tox/DHT/RpcPacketSpec.hs
@@ -1,15 +1,13 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHT.RpcPacketSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                (Proxy (..))
 import           Data.Word                 (Word64)
 import           Network.Tox.DHT.RpcPacket (RpcPacket)
-import qualified Network.Tox.DHT.RpcPacket as RpcPacket
 import           Network.Tox.EncodingSpec
+
 
 spec :: Spec
 spec = do

--- a/src/testsuite/Network/Tox/DHTSpec.hs
+++ b/src/testsuite/Network/Tox/DHTSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.DHTSpec where
 

--- a/src/testsuite/Network/Tox/NodeInfo/HostAddressSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfo/HostAddressSpec.hs
@@ -1,14 +1,11 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfo.HostAddressSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                       (Proxy (..))
 import           Network.Tox.EncodingSpec
 import           Network.Tox.NodeInfo.HostAddress (HostAddress)
-import qualified Network.Tox.NodeInfo.HostAddress as HostAddress
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/NodeInfo/NodeInfoSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfo/NodeInfoSpec.hs
@@ -1,16 +1,13 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfo.NodeInfoSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import qualified Data.Binary                   as Binary (get)
 import qualified Data.Binary.Get               as Binary (Get)
 import           Data.Proxy                    (Proxy (..))
 import           Network.Tox.EncodingSpec
 import           Network.Tox.NodeInfo.NodeInfo (NodeInfo)
-import qualified Network.Tox.NodeInfo.NodeInfo as NodeInfo
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/NodeInfo/PortNumberSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfo/PortNumberSpec.hs
@@ -1,14 +1,11 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfo.PortNumberSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                      (Proxy (..))
 import           Network.Tox.EncodingSpec
 import           Network.Tox.NodeInfo.PortNumber (PortNumber)
-import qualified Network.Tox.NodeInfo.PortNumber as PortNumber
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/NodeInfo/SocketAddressSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfo/SocketAddressSpec.hs
@@ -1,9 +1,7 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfo.SocketAddressSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                         (Proxy (..))
 import           Network.Tox.EncodingSpec

--- a/src/testsuite/Network/Tox/NodeInfo/TransportProtocolSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfo/TransportProtocolSpec.hs
@@ -1,14 +1,11 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfo.TransportProtocolSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                             (Proxy (..))
 import           Network.Tox.EncodingSpec
 import           Network.Tox.NodeInfo.TransportProtocol (TransportProtocol)
-import qualified Network.Tox.NodeInfo.TransportProtocol as TransportProtocol
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/NodeInfoSpec.hs
+++ b/src/testsuite/Network/Tox/NodeInfoSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.NodeInfoSpec where
 

--- a/src/testsuite/Network/Tox/Protocol/PacketKindSpec.hs
+++ b/src/testsuite/Network/Tox/Protocol/PacketKindSpec.hs
@@ -1,16 +1,13 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Protocol.PacketKindSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import qualified Data.Binary                     as Binary (get)
 import qualified Data.Binary.Get                 as Binary (Get)
 import           Data.Proxy                      (Proxy (..))
 import           Network.Tox.EncodingSpec
 import           Network.Tox.Protocol.PacketKind (PacketKind)
-import qualified Network.Tox.Protocol.PacketKind as PacketKind
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/Protocol/PacketSpec.hs
+++ b/src/testsuite/Network/Tox/Protocol/PacketSpec.hs
@@ -1,15 +1,12 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Protocol.PacketSpec where
 
 import           Test.Hspec
-import           Test.QuickCheck
 
 import           Data.Proxy                  (Proxy (..))
 import           Data.Word                   (Word64)
 import           Network.Tox.EncodingSpec
 import           Network.Tox.Protocol.Packet (Packet)
-import qualified Network.Tox.Protocol.Packet as Packet
 
 
 spec :: Spec

--- a/src/testsuite/Network/Tox/ProtocolSpec.hs
+++ b/src/testsuite/Network/Tox/ProtocolSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.ProtocolSpec where
 

--- a/src/testsuite/Network/ToxSpec.hs
+++ b/src/testsuite/Network/ToxSpec.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.ToxSpec where
 

--- a/src/testsuite/Test/Result.hs
+++ b/src/testsuite/Test/Result.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE Safe          #-}
+module Test.Result where
+
+import           Control.Applicative (Applicative, pure, (<*>))
+
+
+data TestResult a
+  = TestSuccess a
+  | TestFailure String
+  deriving (Functor)
+
+
+instance Applicative TestResult where
+  pure = TestSuccess
+
+  TestSuccess f   <*> x = fmap f x
+  TestFailure msg <*> _ = TestFailure msg
+
+
+instance Monad TestResult where
+  return = pure
+  fail = TestFailure
+
+  TestSuccess x   >>= f = f x
+  TestFailure msg >>= _ = TestFailure msg

--- a/src/tox/Network/Tox/Binary.hs
+++ b/src/tox/Network/Tox/Binary.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Safe                #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Network.Tox.Binary where
@@ -31,8 +30,8 @@ import qualified Network.Tox.Protocol.Packet            as T
 import qualified Network.Tox.Protocol.PacketKind        as T
 
 
-typeName :: Typeable a => Proxy a -> String
-typeName = Typeable.tyConName . Typeable.typeRepTyCon . Typeable.typeRep
+typeName :: Typeable a => a -> String
+typeName = Typeable.tyConName . Typeable.typeRepTyCon . Typeable.typeOf
 
 
 --------------------------------------------------------------------------------
@@ -47,7 +46,7 @@ decode = Encoding.decode
 
 decodeC :: forall a. (Typeable a, RPC.MessagePack a)
         => ByteString -> RPC.Client (Maybe a)
-decodeC = RPC.call "Binary.decode" $ typeName (Proxy :: Proxy a)
+decodeC = RPC.call "Binary.decode" $ typeName (undefined :: a)
 
 decodeM :: (Monad m, RPC.MessagePack a, Binary a) => Proxy a -> ByteString -> m (Maybe RPC.Object)
 decodeM (Proxy :: Proxy a) bs =
@@ -89,7 +88,7 @@ encode = Encoding.encode
 
 encodeC :: forall a. (Typeable a, RPC.MessagePack a)
         => a -> RPC.Client ByteString
-encodeC = RPC.call "Binary.encode" $ typeName (Proxy :: Proxy a)
+encodeC = RPC.call "Binary.encode" $ typeName (undefined :: a)
 
 encodeM :: (Monad m, RPC.MessagePack a, Binary a)
         => Proxy a -> RPC.Object -> m ByteString

--- a/src/tox/Network/Tox/Crypto/Box.lhs
+++ b/src/tox/Network/Tox/Crypto/Box.lhs
@@ -1,7 +1,6 @@
 \section{Box}
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.Box where
 

--- a/src/tox/Network/Tox/Crypto/Key.lhs
+++ b/src/tox/Network/Tox/Crypto/Key.lhs
@@ -2,7 +2,6 @@
 
 \begin{code}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable  #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving  #-}
@@ -26,7 +25,6 @@ import qualified Data.Binary.Get                   as Binary (getByteString,
 import qualified Data.Binary.Put                   as Binary (putByteString)
 import qualified Data.ByteString                   as ByteString
 import qualified Data.ByteString.Base16            as Base16
-import qualified Data.ByteString.Char8             as Char8
 import qualified Data.ByteString.Lazy              as LazyByteString
 import           Data.MessagePack                  (MessagePack (..))
 import           Data.Proxy                        (Proxy (..))

--- a/src/tox/Network/Tox/Crypto/KeyPair.lhs
+++ b/src/tox/Network/Tox/Crypto/KeyPair.lhs
@@ -12,7 +12,6 @@ standard group element and the Secret Key.  See the
 \href{https://nacl.cr.yp.to/scalarmult.html}{NaCl documentation} for details.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE NamedFieldPuns     #-}

--- a/src/tox/Network/Tox/Crypto/Nonce.lhs
+++ b/src/tox/Network/Tox/Crypto/Nonce.lhs
@@ -14,7 +14,6 @@ the system as non friends could tie some people's DHT keys and long term keys
 together.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.Crypto.Nonce where
 

--- a/src/tox/Network/Tox/Crypto/Text.lhs
+++ b/src/tox/Network/Tox/Crypto/Text.lhs
@@ -7,7 +7,6 @@ transformed into Cipher Text using the encryption function before it can be
 transmitted over untrusted data channels.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -23,7 +22,6 @@ import           Data.Binary.Put           (runPut)
 import           Data.ByteString           (ByteString)
 import qualified Data.ByteString           as ByteString
 import qualified Data.ByteString.Base16    as Base16
-import qualified Data.ByteString.Char8     as Char8
 import qualified Data.ByteString.Lazy      as LazyByteString
 import           Data.MessagePack          (MessagePack (..))
 import           Data.Typeable             (Typeable)

--- a/src/tox/Network/Tox/DHT/DhtPacket.lhs
+++ b/src/tox/Network/Tox/DHT/DhtPacket.lhs
@@ -21,7 +21,6 @@ protocol never actually sends empty messages, so in reality the minimum size is
 27 bytes for the \href{#ping-service}{Ping Packet}.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE NamedFieldPuns     #-}
@@ -30,9 +29,7 @@ module Network.Tox.DHT.DhtPacket where
 
 import           Control.Applicative            ((<$>), (<*>))
 import           Data.Binary                    (Binary, get, put)
-import           Data.Binary.Get                (Decoder (..),
-                                                 getRemainingLazyByteString,
-                                                 pushChunk, runGetIncremental)
+import           Data.Binary.Get                (getRemainingLazyByteString)
 import           Data.Binary.Put                (putByteString, putByteString,
                                                  runPut)
 import qualified Data.ByteString.Lazy           as LazyByteString

--- a/src/tox/Network/Tox/DHT/DhtState.lhs
+++ b/src/tox/Network/Tox/DHT/DhtState.lhs
@@ -1,7 +1,6 @@
 \section{DHT node state}
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE NamedFieldPuns #-}
 module Network.Tox.DHT.DhtState where
 
@@ -10,7 +9,6 @@ import           Data.Map                      (Map)
 import qualified Data.Map                      as Map
 import qualified Data.Maybe                    as Maybe
 import           Test.QuickCheck.Arbitrary     (Arbitrary, arbitrary, shrink)
-import qualified Test.QuickCheck.Gen           as Gen
 
 import           Network.Tox.Crypto.Key        (PublicKey)
 import           Network.Tox.Crypto.KeyPair    (KeyPair)

--- a/src/tox/Network/Tox/DHT/Distance.lhs
+++ b/src/tox/Network/Tox/DHT/Distance.lhs
@@ -1,13 +1,12 @@
 \section{Distance}
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash                  #-}
 {-# LANGUAGE Trustworthy                #-}
 module Network.Tox.DHT.Distance where
 
-import           Control.Applicative       ((<$>), (<*>))
+import           Control.Applicative       ((<$>))
 import           Control.Arrow             (first)
 import           Data.Bits                 (xor)
 import           Data.Monoid               (Monoid, mappend, mempty)

--- a/src/tox/Network/Tox/DHT/KBuckets.lhs
+++ b/src/tox/Network/Tox/DHT/KBuckets.lhs
@@ -5,13 +5,12 @@ certain key called the base key.  The base key is constant throughout the
 lifetime of a k-buckets instance.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns             #-}
 {-# LANGUAGE Trustworthy                #-}
 module Network.Tox.DHT.KBuckets where
 
-import           Control.Applicative           ((<$>), (<*>))
+import           Control.Applicative           ((<$>))
 import           Data.Binary                   (Binary)
 import           Data.Map                      (Map)
 import qualified Data.Map                      as Map

--- a/src/tox/Network/Tox/DHT/NodesRequest.lhs
+++ b/src/tox/Network/Tox/DHT/NodesRequest.lhs
@@ -9,22 +9,18 @@
 The DHT Public Key sent in the request is the one the sender is searching for.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE Safe               #-}
 module Network.Tox.DHT.NodesRequest where
 
-import           Control.Applicative             ((<$>))
-import           Data.Binary                     (Binary, get, put)
-import           Data.MessagePack                (MessagePack)
-import           Data.Typeable                   (Typeable)
-import           GHC.Generics                    (Generic)
-import           Network.Tox.Crypto.Key          (PublicKey)
-import           Network.Tox.Encoding            (getBool, putBool)
-import qualified Network.Tox.Protocol.PacketKind as PacketKind
-import           Test.QuickCheck.Arbitrary       (Arbitrary, arbitrary)
-import qualified Test.QuickCheck.Gen             as Gen
+import           Control.Applicative       ((<$>))
+import           Data.Binary               (Binary)
+import           Data.MessagePack          (MessagePack)
+import           Data.Typeable             (Typeable)
+import           GHC.Generics              (Generic)
+import           Network.Tox.Crypto.Key    (PublicKey)
+import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 
 
 {-------------------------------------------------------------------------------

--- a/src/tox/Network/Tox/DHT/NodesResponse.lhs
+++ b/src/tox/Network/Tox/DHT/NodesResponse.lhs
@@ -14,7 +14,6 @@ Nodes responses should contain the 4 closest nodes that the sender of the
 response has in their list of known nodes.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE Safe               #-}

--- a/src/tox/Network/Tox/DHT/RpcPacket.lhs
+++ b/src/tox/Network/Tox/DHT/RpcPacket.lhs
@@ -1,5 +1,4 @@
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/tox/Network/Tox/ExternalTest.hs
+++ b/src/tox/Network/Tox/ExternalTest.hs
@@ -1,4 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE LambdaCase  #-}
 {-# LANGUAGE Trustworthy #-}
 module Network.Tox.ExternalTest where

--- a/src/tox/Network/Tox/NodeInfo/HostAddress.lhs
+++ b/src/tox/Network/Tox/NodeInfo/HostAddress.lhs
@@ -10,7 +10,6 @@ Thus, when packed together with the Transport Protocol, the first bit of the
 packed byte is the protocol and the next 7 bits are the address family.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE LambdaCase         #-}
@@ -25,17 +24,11 @@ import qualified Data.Binary.Bits.Get      as Bits
 import qualified Data.Binary.Bits.Put      as Bits
 import qualified Data.Binary.Get           as Bytes
 import qualified Data.Binary.Put           as Bytes
-import           Data.Bits                 (shiftL, shiftR, (.&.), (.|.))
 import qualified Data.IP                   as IP
-import           Data.List                 as List
-import           Data.List.Split           as List
-import           Data.Maybe                (listToMaybe, mapMaybe)
 import           Data.MessagePack          (MessagePack)
 import           Data.Typeable             (Typeable)
-import           Data.Word                 (Word16, Word8)
 import           GHC.Generics              (Generic)
 import qualified Network.Socket            as Socket (HostAddress, HostAddress6)
-import           Numeric                   (readHex, showHex)
 import           Test.QuickCheck.Arbitrary (Arbitrary, arbitrary)
 import qualified Test.QuickCheck.Gen       as Gen
 import           Text.Read                 (readPrec)

--- a/src/tox/Network/Tox/NodeInfo/NodeInfo.lhs
+++ b/src/tox/Network/Tox/NodeInfo/NodeInfo.lhs
@@ -40,7 +40,6 @@ The reason for these numbers is because the numbers on Linux for IPv4 and IPv6
 \texttt{10}.  The TCP numbers are just the UDP numbers \texttt{+ 128}.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE Safe               #-}

--- a/src/tox/Network/Tox/NodeInfo/PortNumber.lhs
+++ b/src/tox/Network/Tox/NodeInfo/PortNumber.lhs
@@ -4,7 +4,6 @@ A Port Number is a 16 bit number.  Its binary representation is a Big Endian 16
 bit unsigned integer (2 bytes).
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/src/tox/Network/Tox/NodeInfo/SocketAddress.lhs
+++ b/src/tox/Network/Tox/NodeInfo/SocketAddress.lhs
@@ -5,7 +5,6 @@ Transport Protocol, it is sufficient information to address a network port on
 any internet host.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE LambdaCase         #-}
@@ -21,7 +20,6 @@ import qualified Data.Binary.Put                        as Binary (Put)
 import           Data.MessagePack                       (MessagePack)
 import           Data.Typeable                          (Typeable)
 import           GHC.Generics                           (Generic)
-import qualified Network.Socket                         as Socket
 import           Network.Tox.Encoding                   (bitGet, bitPut)
 import           Network.Tox.NodeInfo.HostAddress       (HostAddress (..))
 import qualified Network.Tox.NodeInfo.HostAddress       as HostAddress

--- a/src/tox/Network/Tox/Protocol/Packet.lhs
+++ b/src/tox/Network/Tox/Protocol/Packet.lhs
@@ -1,5 +1,4 @@
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE Safe               #-}
@@ -8,7 +7,6 @@ module Network.Tox.Protocol.Packet where
 import           Control.Applicative             ((<$>), (<*>))
 import           Data.Binary                     (Binary)
 import           Data.MessagePack                (MessagePack)
-import           Data.Proxy                      (Proxy)
 import           Data.Typeable                   (Typeable)
 import           GHC.Generics                    (Generic)
 import           Network.Tox.Protocol.PacketKind (PacketKind)

--- a/test/hstox/TestServer.lhs
+++ b/test/hstox/TestServer.lhs
@@ -8,7 +8,6 @@ the Tox protocol following the architecture specified in this document is
 correct.
 
 \begin{code}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE Safe       #-}
 module Main (main) where

--- a/tools/MessagePackParser/MessagePackParser.hs
+++ b/tools/MessagePackParser/MessagePackParser.hs
@@ -1,8 +1,5 @@
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
-{-# LANGUAGE Safe #-}
----------------------------
---
--- A MessagePack parser.
+{-# LANGUAGE Trustworthy #-}
+-- | A MessagePack parser.
 --
 -- Example usage:
 --   $ echo -ne "\x94\x01\xa1\x32\xa1\x33\xa4\x50\x6f\x6f\x66" | ./msgpack-parser
@@ -21,7 +18,7 @@
 -- considers it as binary data.
 --
 -- Therefore, given a valid input, the tool has the following property
---   $ cat input.bin | ./msgpack-parser | ./msgpack-parser
+--   $ ./msgpack-parser < input.bin | ./msgpack-parser
 -- will output back the contents of input.bin.
 --
 -- In case the input is impossible to parse, nothing is output.
@@ -39,12 +36,16 @@ import qualified Data.ByteString.Lazy       as L
 import qualified Data.ByteString.Lazy.Char8 as L8
 import           Data.Maybe                 (fromMaybe)
 import           Data.MessagePack           (Object, pack, unpack)
+import           Text.Groom                 (groom)
 import           Text.Read                  (readMaybe)
+
 
 parse :: L.ByteString -> L.ByteString
 parse str = fromMaybe L.empty $
-  (pack <$> ((readMaybe . L8.unpack) str :: Maybe Object))
-  <|> ((L8.pack . flip (++) "\n" . show) <$> (unpack str :: Maybe Object))
+  pack <$> (readMaybe $ L8.unpack str :: Maybe Object)
+  <|>
+  L8.pack . flip (++) "\n" . groom <$> (unpack str :: Maybe Object)
+
 
 main :: IO ()
 main = parse <$> L.getContents >>= L.putStr


### PR DESCRIPTION
We now use the Text.Groom package to pretty-print the output from "show" when
using the msgpack-parser tool. This helps a human understand the output better,
especially when the output becomes larger.

This commit also removes all unused imports and improves compatibility with
older versions of GHC (7.6). We now use lists instead of vectors in the msgpack
data model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/37)
<!-- Reviewable:end -->
