### PR TITLE
Record all test inputs, not just the last one per method.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ CLANG_TIDY_FLAGS :=					\
 
 all: check $(DOCS)
 
+fuzz: .build.stamp
+	@echo "Cleaning up previous results"
+	@$(MAKE) -C test/toxcore clean
+	@echo "Generating initial test inputs"
+	@rm -f test/toxcore/test-inputs/*
+	@tools/run-tests toxcore --qc-max-success=1 --format=silent
+	@$(MAKE) -C test/toxcore master
+
 check: dist/hpc/tix/hstox/hstox.tix
 	hpc markup $(HPC_DIRS) --destdir=dist/hpc/html $< > /dev/null
 	hpc report $(HPC_DIRS) $<

--- a/test/toxcore/Makefile
+++ b/test/toxcore/Makefile
@@ -1,6 +1,10 @@
+# Don't bind to a CPU core. afl-fuzz doesn't release them again.
+export AFL_NO_AFFINITY := 1
+
 CFLAGS	:=					\
 	-std=gnu99				\
 	-Wall					\
+	-g3					\
 	-DCONFIGURED=1				\
 	-Imsgpack-c/include			\
 	-Itoxcore/toxcore			\
@@ -87,7 +91,7 @@ test-findings: /Volumes/RAM\ Disk
 else
 test-findings: /dev/shm
 	mkdir -p "$</$@"
-	ln -sf "$</$@" $@
+	test -d $@ || ln -sf "$</$@" $@
 endif
 
 clean:

--- a/test/toxcore/binary_encode.c
+++ b/test/toxcore/binary_encode.c
@@ -120,6 +120,9 @@ METHOD(array, Binary_encode, NodeInfo) {
   uint8_t packed_node[PACKED_NODE_SIZE_IP6];
 
   int len = pack_nodes(packed_node, sizeof packed_node, &node, 1);
+  if (len < 0) {
+    return failure;
+  }
 
   SUCCESS {
     msgpack_pack_bin(res, len);

--- a/test/toxcore/driver.c
+++ b/test/toxcore/driver.c
@@ -52,10 +52,16 @@ static bool type_check(msgpack_packer *pk, msgpack_object req, int index,
 }
 
 static int write_sample_input(msgpack_object req) {
+  static unsigned int n;
+
+  char filename[256];
   msgpack_object_str name = req.via.array.ptr[2].via.str;
-  char filename[128] = "test/toxcore/test-inputs/";
-  memcpy(filename + strlen(filename), name.ptr, name.size);
+  snprintf(filename, sizeof filename - name.size,
+           "test/toxcore/test-inputs/%04u-", n++);
+
+  assert(sizeof filename - strlen(filename) > name.size + 4);
   memcpy(filename + strlen(filename) + name.size, ".mp", 4);
+  memcpy(filename + strlen(filename), name.ptr, name.size);
 
   int fd = open(filename, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
   if (fd < 0)

--- a/test/toxcore/methods.c
+++ b/test/toxcore/methods.c
@@ -5,6 +5,7 @@
 #include <crypto_core.h>
 #include <net_crypto.h>
 
+char const *const failure = "Failure";
 char const *const pending = "Pending";
 char const *const unimplemented = "Unimplemented";
 

--- a/test/toxcore/methods.h
+++ b/test/toxcore/methods.h
@@ -44,5 +44,6 @@ METHOD(array, Binary, encode);
 char const *call_method(msgpack_object_str name, msgpack_object_array args,
                         msgpack_packer *res);
 
+extern char const *const failure;
 extern char const *const pending;
 extern char const *const unimplemented;


### PR DESCRIPTION
The inputs vary wildly for binary encode/decode methods, so in order to reach
all paths, we now save all 1600+ inputs. This does create a lot of useless
input, because most of them (about 95-99%) are the same. Reducing the maximum
number of passes in quickcheck to 1 solves this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/57)
<!-- Reviewable:end -->
