### PR TITLE
Add a short delay before the toxcore test run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ include configure.mk
 # Test flavour. See test/toxcore/Makefile for choices.
 TEST	:= vanilla
 
-SOURCES	:= $(shell find src test tools -name "*.*hs" -or -name "*.c" -or -name "*.h")
+SRCDIRS	:= src test tools
+SOURCES	:= $(shell find $(SRCDIRS) -name "*.*hs" -or -name "*.c" -or -name "*.h")
 
 export LD_LIBRARY_PATH := $(HOME)/.cabal/extra-dist/lib
 
@@ -68,7 +69,7 @@ clean:
 
 
 build: .build.stamp
-.build.stamp: $(SOURCES) .configure.stamp .format.stamp .lint.stamp $(SUT_TOXCORE)
+.build.stamp: $(SOURCES) .configure.stamp .format.stamp .lint.stamp
 	rm -f $(wildcard *.tix)
 	cabal build $(CABAL_JOBS)
 	@touch $@
@@ -107,7 +108,7 @@ libsodium: .libsodium.stamp
 
 format: .format.stamp
 .format.stamp: $(SOURCES) .configure.stamp
-	if which stylish-haskell; then tools/format-haskell -i src; fi
+	if which stylish-haskell; then tools/format-haskell -i $(SRCDIRS); fi
 	if which $(CLANG_FORMAT); then $(CLANG_FORMAT) $(CLANG_FORMAT_FLAGS) test/toxcore/*.[ch]; fi
 	if which $(CLANG_TIDY); then $(CLANG_TIDY) $(CLANG_TIDY_FLAGS); fi
 	@touch $@

--- a/hstox.cabal
+++ b/hstox.cabal
@@ -140,6 +140,56 @@ executable msgpack-parser
   if flag(library-only)
     buildable: False
 
+executable sut-toxcore
+  default-language: Haskell2010
+  hs-source-dirs: test/toxcore
+  ghc-options: -Wall
+  build-depends: base < 5
+  main-is: sut-toxcore.hs
+  extra-libraries: pthread sodium
+  include-dirs:
+      test/toxcore/msgpack-c/include
+      test/toxcore/toxcore/toxcore
+  c-sources:
+      test/toxcore/binary_decode.c
+      test/toxcore/binary_encode.c
+      test/toxcore/driver.c
+      test/toxcore/fuzz_main.c
+      test/toxcore/methods.c
+      test/toxcore/msgpack-c/src/objectc.c
+      test/toxcore/msgpack-c/src/unpack.c
+      test/toxcore/msgpack-c/src/version.c
+      test/toxcore/msgpack-c/src/vrefbuffer.c
+      test/toxcore/msgpack-c/src/zone.c
+      test/toxcore/packet_kinds.c
+      test/toxcore/test_main.c
+      test/toxcore/toxcore/toxcore/assoc.c
+      test/toxcore/toxcore/toxcore/crypto_core.c
+      test/toxcore/toxcore/toxcore/DHT.c
+      test/toxcore/toxcore/toxcore/friend_connection.c
+      test/toxcore/toxcore/toxcore/friend_requests.c
+      test/toxcore/toxcore/toxcore/group.c
+      test/toxcore/toxcore/toxcore/LAN_discovery.c
+      test/toxcore/toxcore/toxcore/list.c
+      test/toxcore/toxcore/toxcore/logger.c
+      test/toxcore/toxcore/toxcore/Messenger.c
+      test/toxcore/toxcore/toxcore/net_crypto.c
+      test/toxcore/toxcore/toxcore/network.c
+      test/toxcore/toxcore/toxcore/onion_announce.c
+      test/toxcore/toxcore/toxcore/onion.c
+      test/toxcore/toxcore/toxcore/onion_client.c
+      test/toxcore/toxcore/toxcore/ping_array.c
+      test/toxcore/toxcore/toxcore/ping.c
+      test/toxcore/toxcore/toxcore/TCP_client.c
+      test/toxcore/toxcore/toxcore/TCP_connection.c
+      test/toxcore/toxcore/toxcore/TCP_server.c
+      test/toxcore/toxcore/toxcore/tox.c
+      test/toxcore/toxcore/toxcore/tox_group.c
+      test/toxcore/toxcore/toxcore/util.c
+      test/toxcore/util.c
+  if flag(library-only)
+    buildable: False
+
 test-suite test-hstox
   default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/test/test-toxcore.hs
+++ b/test/test-toxcore.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+import           Control.Concurrent  (threadDelay)
 import           System.Environment  (getArgs, withArgs)
 import           System.Process      (createProcess, proc, terminateProcess)
 
@@ -11,5 +12,8 @@ main :: IO ()
 main = do
   args <- getArgs
   (_, _, _, sut) <- createProcess $ proc "dist/build/sut-toxcore/sut-toxcore" []
+  -- 100ms delay to give the SUT time to set up its socket before we try to
+  -- build connections in the test runner.
+  threadDelay $ 100 * 1000
   withArgs (["--print-cpu-time", "--color"] ++ args) TestSuite.main
   terminateProcess sut

--- a/test/toxcore/binary_decode.c
+++ b/test/toxcore/binary_decode.c
@@ -101,7 +101,8 @@ METHOD(bin, Binary_decode, PacketKind) {
       msgpack_pack_nil(res);
     } else {
       uint8_t kind = args.ptr[0];
-      for (size_t i = 0; i < sizeof packet_kinds / sizeof *packet_kinds; i++) {
+      size_t  i;
+      for (i = 0; i < sizeof packet_kinds / sizeof *packet_kinds; i++) {
         if (packet_kinds[i] == kind) {
           msgpack_pack_fix_uint8(res, i);
           return 0;

--- a/test/toxcore/fuzz_main.c
+++ b/test/toxcore/fuzz_main.c
@@ -7,6 +7,9 @@
 // See https://github.com/mcarpenter/afl/blob/master/llvm_mode/README.llvm.
 #define ITERATIONS 1000
 
+#ifdef __GLASGOW_HASKELL__
+#define main fuzz_main
+#endif
 int main(int argc, char **argv) {
   struct settings cfg = {false, false};
 #ifdef __AFL_LOOP

--- a/test/toxcore/sut-toxcore.hs
+++ b/test/toxcore/sut-toxcore.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+
+foreign import ccall test_main :: IO ()
+
+
+main :: IO ()
+main = test_main

--- a/test/toxcore/test_main.c
+++ b/test/toxcore/test_main.c
@@ -30,6 +30,9 @@ static char const *error_desc(int code) {
   return "Unknown error code";
 }
 
+#ifdef __GLASGOW_HASKELL__
+#define main test_main
+#endif
 int main(void) {
   struct settings cfg    = {true, true};
   uint32_t        result = network_main(cfg, PORT, TIMEOUT);


### PR DESCRIPTION
The test suite can sometimes start too fast while the sut has not
started up, yet. This adds a short delay to avoid the issue. The real
fix would be to try connecting until it's up, and then start the test
suite. That is a bit too much work for (probably) no gain, so we're
using a delay instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/73)
<!-- Reviewable:end -->
