### PR TITLE
Fix docker image uploader script.

### DIFF
--- a/.travis/android-after_success
+++ b/.travis/android-after_success
@@ -2,7 +2,7 @@
 
 # Don't print this, as it contains the docker password.
 set +x
-[ -z "$DOCKER_PASSWORD" ] || exit
+[ -n "$DOCKER_PASSWORD" ] || exit
 docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
 set -x
 


### PR DESCRIPTION
It used -z instead of -n to check for non-zero-length strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/77)
<!-- Reviewable:end -->
