### PR TITLE
tox_group.c is going away; stop depending on it.

### DIFF
--- a/hstox.cabal
+++ b/hstox.cabal
@@ -185,8 +185,8 @@ executable sut-toxcore
       test/toxcore/toxcore/toxcore/TCP_client.c
       test/toxcore/toxcore/toxcore/TCP_connection.c
       test/toxcore/toxcore/toxcore/TCP_server.c
-      test/toxcore/toxcore/toxcore/tox.c
-      test/toxcore/toxcore/toxcore/tox_group.c
+      --test/toxcore/toxcore/toxcore/tox.c
+      --test/toxcore/toxcore/toxcore/tox_group.c
       test/toxcore/toxcore/toxcore/util.c
       test/toxcore/util.c
   if flag(library-only)


### PR DESCRIPTION
TokTok/toxcore#135 will remove tox_group.c. Currently, tox.c depends on it,
but nothing in sut-toxcore needs that, so we can safely omit the files when
compiling sut-toxcore. After 135 is submitted, we'll re-enable tox.c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hstox/78)
<!-- Reviewable:end -->
